### PR TITLE
Added OneSignal to Backend

### DIFF
--- a/src/Conference.Backend/Conference.Backend.csproj
+++ b/src/Conference.Backend/Conference.Backend.csproj
@@ -215,6 +215,7 @@
       <HintPath>..\packages\WebApiThrottle.1.4.3\lib\net45\WebApiThrottle.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web.Extensions" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
@@ -254,6 +255,7 @@
     <Compile Include="Models\ConferenceContext.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Controllers\BaseController.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\Push.html" />

--- a/src/Conference.Backend/Controllers/AnnouncementController.cs
+++ b/src/Conference.Backend/Controllers/AnnouncementController.cs
@@ -11,7 +11,7 @@ using System.Configuration;
 namespace Conference.Backend.Controllers
 {
     [MobileAppController]
-    public class AnnouncementController : ApiController
+    public class AnnouncementController : BaseController
     {
         // POST api/Announcement
 
@@ -21,8 +21,10 @@ namespace Conference.Backend.Controllers
             HttpStatusCode ret = HttpStatusCode.InternalServerError;
 
             if (string.IsNullOrWhiteSpace(message) || password != ConfigurationManager.AppSettings["NotificationsPassword"])
-                return Request.CreateResponse(ret);
+            return Request.CreateResponse(ret);
 
+            // TODO if this even necessary? When an annoucement is made, should send a push notification?
+            SendToOneSignal(message);
 
             try
             {

--- a/src/Conference.Backend/Controllers/BaseController.cs
+++ b/src/Conference.Backend/Controllers/BaseController.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using System.Net;
+using System.Text;
+using System.Web.Http;
+using System.Web.Script.Serialization;
+
+namespace Conference.Backend.Controllers
+{
+    public class BaseController : ApiController
+    {
+        protected void SendToOneSignal(string message)
+        {
+            var request = WebRequest.Create("https://onesignal.com/api/v1/notifications") as HttpWebRequest;
+
+            request.KeepAlive = true;
+            request.Method = "POST";
+            request.ContentType = "application/json; charset=utf-8";
+
+            request.Headers.Add("authorization", "Basic ZjdlZTE4NDQtNDhiOS00Njc2LWI4YzgtODhiZWZkNGRjYzA1");
+
+            var serializer = new JavaScriptSerializer();
+            var obj = new
+            {
+                app_id = "c233a844-5672-49d8-8440-88c7b8d63233",
+                contents = new { en = message },
+                included_segments = new string[] { "All" }
+            };
+            var param = serializer.Serialize(obj);
+            byte[] byteArray = Encoding.UTF8.GetBytes(param);
+
+            string responseContent = null;
+
+            try
+            {
+                using (var writer = request.GetRequestStream())
+                {
+                    writer.Write(byteArray, 0, byteArray.Length);
+                }
+
+                using (var response = request.GetResponse() as HttpWebResponse)
+                {
+                    using (var reader = new StreamReader(response.GetResponseStream()))
+                    {
+                        responseContent = reader.ReadToEnd();
+                    }
+                }
+            }
+            catch (WebException ex)
+            {
+                System.Diagnostics.Debug.WriteLine(ex.Message);
+                System.Diagnostics.Debug.WriteLine(new StreamReader(ex.Response.GetResponseStream()).ReadToEnd());
+            }
+
+            System.Diagnostics.Debug.WriteLine(responseContent);
+        }
+    }
+}

--- a/src/Conference.Backend/Controllers/EvolveNotificationsController.cs
+++ b/src/Conference.Backend/Controllers/EvolveNotificationsController.cs
@@ -1,60 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
+﻿using System.Net;
 using System.Net.Http;
 using System.Web.Http;
-using Conference.Backend.Models;
-using System.Web;
-using System.Threading.Tasks;
 using Microsoft.Azure.Mobile.Server.Config;
-using Conference.Backend.Identity;
 using System.Configuration;
 
 namespace Conference.Backend.Controllers
 {
     [MobileAppController]
-    public class ConferenceNotificationsController : ApiController
+    public class ConferenceNotificationsController : BaseController
     {
-        
-        public async Task<HttpResponseMessage> Post(string pns, string password, [FromBody]string message)
+        // TODO may need some improve here
+        public HttpResponseMessage Post(string pns, string password, [FromBody]string message)
         {
-
-            Microsoft.Azure.NotificationHubs.NotificationOutcome outcome = null;
             HttpStatusCode ret = HttpStatusCode.InternalServerError;
 
             if (string.IsNullOrWhiteSpace(message) || password != ConfigurationManager.AppSettings["NotificationsPassword"])
                 return Request.CreateResponse(ret);
 
+            SendToOneSignal(message);
 
-            switch (pns.ToLower())
-            {
-                case "wns":
-                    // Windows 8.1 / Windows Phone 8.1
-                    var toast = @"<toast><visual><binding template=""ToastText01""><text id=""1"">" +
-                                message + "</text></binding></visual></toast>";
-                    outcome = await ConferenceNotifications.Instance.Hub.SendWindowsNativeNotificationAsync(toast);
-                    break;
-                case "apns":
-                    // iOS
-                    var alert = "{\"aps\":{\"alert\":\"" + message + "\"}}";
-                    outcome = await ConferenceNotifications.Instance.Hub.SendAppleNativeNotificationAsync(alert);
-                    break;
-                case "gcm":
-                    // Android
-                    var notif = "{ \"data\" : {\"message\":\"" + message + "\"}}";
-                    outcome = await ConferenceNotifications.Instance.Hub.SendGcmNativeNotificationAsync(notif);
-                    break;
-            }
-
-            if (outcome != null)
-            {
-                if (!((outcome.State == Microsoft.Azure.NotificationHubs.NotificationOutcomeState.Abandoned) ||
-                    (outcome.State == Microsoft.Azure.NotificationHubs.NotificationOutcomeState.Unknown)))
-                {
-                    ret = HttpStatusCode.OK;
-                }
-            }
+            ret = HttpStatusCode.OK;
 
             return Request.CreateResponse(ret);
         }

--- a/src/Conference.Backend/Views/Push.html
+++ b/src/Conference.Backend/Views/Push.html
@@ -17,10 +17,6 @@
         <textarea name="password" id="password" cols="40" rows="1" size="256"></textarea>
         <br />
         <h3>Notification</h3>
-        Services<br />
-        <input type="checkbox" id="apns" name="apns" value="apns" checked /> iOS
-        <input type="checkbox" id="gcm" name="gcm" value="gcm" checked /> Android
-        <input type="checkbox" id="wns" name="wns" value="wns" checked /> Windows
         <br /> <br />
         <textarea name="message" id="message" cols="40" rows="5" size="256"></textarea>
         <br />
@@ -81,78 +77,26 @@
             status.innerHTML = "Sending notification : ";
             button.disabled = true;
 
-            var apns = document.getElementById("apns").checked;
-            var gcm = document.getElementById("gcm").checked;
-            var wns = document.getElementById("wns").checked;
+            var http = new XMLHttpRequest();
+                http.open("POST", "/api/conferencenotifications?pns=apns&password="+password.value, true);
 
-            if (apns) {
-                var apnsHttp = new XMLHttpRequest();
-                apnsHttp.open("POST", "/api/conferencenotifications?pns=apns&password="+password.value, true);
-
-                apnsHttp.onreadystatechange = function () {
-                    if (apnsHttp.readyState == 4) {
-                        if (apnsHttp.status == 200) {
-                            status.innerHTML += "\n iOS: Sent " + apnsHttp.responseText;
+                http.onreadystatechange = function () {
+                    if (http.readyState == 4) {
+                        if (http.status == 200) {
+                            status.innerHTML += "\n Notification: Sent " + http.responseText;
                         }
                         else {
-                            status.innerHTML += "\n iOS: Error " + apnsHttp.statusText;
+                            status.innerHTML += "\n Notification: Error " + http.statusText;
                         }
                     }
                 }
 
                 var toSendA = JSON.stringify(message.value);
-                apnsHttp.setRequestHeader("Content-type", "application/json;charset=UTF-8");
-                apnsHttp.setRequestHeader("Content-length", toSendA.length);
-                apnsHttp.setRequestHeader("Connection", "close");
-                apnsHttp.setRequestHeader("ZUMO-API-VERSION", "2.0.0");
-                apnsHttp.send(toSendA);
-            }
-
-            if (gcm) {
-                var gcmHttp = new XMLHttpRequest();
-                gcmHttp.open("POST", "/api/conferencenotifications?pns=gcm&password=" + password.value, true);
-                gcmHttp.onreadystatechange = function () {
-                    if (gcmHttp.readyState == 4) {
-                        if (gcmHttp.status == 200) {
-                            status.innerHTML += "\n Android: Sent " + gcmHttp.responseText;
-                        }
-                        else {
-                            status.innerHTML += "\n Android: Error " + gcmHttp.statusText;
-                        }
-                    }
-                }
-
-                var toSendA = JSON.stringify(message.value);
-                gcmHttp.setRequestHeader("Content-type", "application/json;charset=UTF-8");
-                gcmHttp.setRequestHeader("Content-length", toSendA.length);
-                gcmHttp.setRequestHeader("Connection", "close");
-                gcmHttp.setRequestHeader("ZUMO-API-VERSION", "2.0.0");
-                gcmHttp.send(toSendA);
-            }
-
-            if (wns) {
-                var wnsHttp = new XMLHttpRequest();
-                wnsHttp.open("POST", "/api/conferencenotifications?pns=wns&password=" + password.value, true);
-               
-                wnsHttp.onreadystatechange = function () {
-                    if (wnsHttp.readyState == 4) {
-                        if (wnsHttp.status == 200) {
-                            status.innerHTML += "\n Windows: Sent " + wnsHttp.responseText;
-                        }
-                        else {
-                            status.innerHTML += "\n Windows: Error " + wns.statusText;
-                        }
-                    }
-                }
-
-                var toSendW = JSON.stringify(message.value);
-                wnsHttp.setRequestHeader("Content-type", "application/json;charset=UTF-8");
-                wnsHttp.setRequestHeader("Content-length", toSendW.length);
-                wnsHttp.setRequestHeader("Connection", "close");
-
-                wnsHttp.setRequestHeader("ZUMO-API-VERSION", "2.0.0");
-                wnsHttp.send(toSendW);
-            }
+                http.setRequestHeader("Content-type", "application/json;charset=UTF-8");
+                http.setRequestHeader("Content-length", toSendA.length);
+                http.setRequestHeader("Connection", "close");
+                http.setRequestHeader("ZUMO-API-VERSION", "2.0.0");
+                http.send(toSendA);
 
             button.disabled = false;
         }


### PR DESCRIPTION
## What's new?

In this updated We have added OneSignal call for push notification functionality through the temp push portal. 

## Notes
This implementation only include "All Subscribers" calls. I don't think We need to integrate segments / targets but it can be implemented at any time. Target example could be: gender, age, type of content, etc.

 To test this, you can use the /Views/Push.html portal.